### PR TITLE
+ Adding metrics and a bunch of tests.

### DIFF
--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -122,3 +122,395 @@ class Metric(object):
             if self._num_classes != num_classes:
                 raise ValueError("Input data number of classes has changed from {} to {}"
                                  .format(self._num_classes, num_classes))
+
+
+class BasePrecisionRecall(Metric):
+    def __init__(self, average=False, is_multilabel=False):
+        self._average = average
+        self._true_positives = None
+        self._positives = None
+        self._epsilon = 1e-20
+        super(BasePrecisionRecall, self).__init__(is_multilabel=is_multilabel)
+
+    @abc.abstractmethod
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Compute a Precision or Recall metric.
+
+         Args:
+             predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+             targets (:obj:`torch.Tensor`): The ground truth.
+
+         Raises:
+             NotImplementedError: if not overwritten by subclass.
+        """
+        raise NotImplementedError()
+
+
+class Accuracy(Metric):
+    """Calculate Accuracy."""
+
+    def __init__(self, is_multilabel=False):
+        """Class constructor."""
+        super().__init__(is_multilabel=is_multilabel)
+
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Compute accuracy.
+
+        Args:
+            predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+            targets (:obj:`torch.Tensor`): The ground truth.
+
+        Returns:
+            float: The batch's accuracy.
+        """
+        _num_correct = 0
+
+        predictions, targets = self._check_shapes(predictions, targets)
+        self._select_metric_type(predictions, targets)
+
+        if self._type == "binary":
+            correct = torch.eq(predictions.type(targets.type()), targets).view(-1)
+        elif self._type == "multiclass":
+            indices = torch.argmax(predictions, dim=1)
+            correct = torch.eq(indices, targets).view(-1)
+        elif self._type == "multilabel":
+            # if y, y_pred shape is (N, C, ...) -> (N x ..., C)
+            num_classes = predictions.size(1)
+            last_dim = predictions.ndimension()
+            y_pred = torch.transpose(predictions, 1, last_dim - 1).reshape(-1, num_classes)
+            y = torch.transpose(targets, 1, last_dim - 1).reshape(-1, num_classes)
+            correct = torch.all(y == y_pred.type_as(y), dim=-1)
+
+        _num_correct = torch.sum(correct).item()
+
+        if correct.shape[0] == 0:
+            raise ValueError('Accuracy metric must have at least one example before it can be computed.')
+
+        return _num_correct / correct.shape[0]
+
+
+class TopKCategoricalAccuracy(Metric):
+    """Calculate the top-k categorical accuracy."""
+
+    def __init__(self, k=5):
+        super(TopKCategoricalAccuracy, self).__init__()
+        self._k = k
+
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Calculate Top-K Accuracy.
+
+        Args:
+            predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+            targets (:obj:`torch.Tensor`): The ground truth.
+
+        Returns:
+            float: The batch's top K categorical accuracy.
+        """
+        predictions, targets = self._check_shapes(predictions, targets)
+
+        sorted_indices = torch.topk(predictions, self._k, dim=1)[1]
+        expanded_targets = targets.view(-1, 1).expand(-1, self._k)
+        correct = torch.sum(torch.eq(sorted_indices, expanded_targets), dim=1)
+        _num_correct = torch.sum(correct).item()
+        _num_examples = correct.shape[0]
+
+        if _num_examples == 0:
+            raise ValueError("TopKCategoricalAccuracy must have at"
+                             "least one example before it can be computed.")
+        return _num_correct / _num_examples
+
+
+class MeanSquaredError(Metric):
+    """Calculate the Mean Squared Error."""
+
+    def __init__(self):
+        """Class constructor."""
+        super().__init__()
+
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Compute Mean Squared Error.
+
+              Args:
+                  predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+                  targets (:obj:`torch.Tensor`): The ground truth.
+
+              Returns:
+                  float: The batch's mean squared error.
+        """
+        predictions, targets = self._check_shapes(predictions, targets)
+
+        squared_errors = torch.pow(predictions - targets.view_as(predictions), 2)
+        _sum_of_squared_errors = torch.sum(squared_errors).item()
+        _num_examples = targets.shape[0]
+
+        if _num_examples == 0:
+            raise ValueError('MeanSquaredError must have at least one example before it can be computed.')
+
+        return _sum_of_squared_errors / _num_examples
+
+
+class RootMeanSquaredError(MeanSquaredError):
+    """Calculate the Root Mean Squared Error."""
+
+    def __init__(self):
+        """Class constructor."""
+        super().__init__()
+
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Compute Root Mean Squared Error.
+
+        Args:
+            predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+            targets (:obj:`torch.Tensor`): The ground truth.
+
+        Returns:
+            float: The batch's root mean squared error.
+        """
+        mse = super(RootMeanSquaredError, self).compute(predictions, targets)
+        return math.sqrt(mse)
+
+
+class MeanAbsoluteError(Metric):
+    """Calculate the Mean Absolute Error."""
+
+    def __init__(self):
+        """Class constructor."""
+        super().__init__()
+
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Compute Mean Absolute Error.
+
+        Args:
+            predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+            targets (:obj:`torch.Tensor`): The ground truth.
+
+        Returns:
+            float: The batch's mean absolute error..
+        """
+        predictions, targets = self._check_shapes(predictions, targets)
+
+        absolute_errors = torch.abs(predictions - targets.view_as(predictions))
+        _sum_of_absolute_errors = torch.sum(absolute_errors).item()
+        _num_examples = targets.shape[0]
+
+        if _num_examples == 0:
+            raise ValueError('MeanAbsoluteError must have at least one example before it can be computed.')
+
+        return _sum_of_absolute_errors / _num_examples
+
+
+class MeanPairwiseDistance(Metric):
+    """Calculate the Mean Pairwise Distance."""
+
+    def __init__(self, p=2, epsilon=1e-6):
+        """Class constructor."""
+        super(MeanPairwiseDistance, self).__init__()
+        self._p = p
+        self._epsilon = epsilon
+
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Compute Mean Pairwise Distance.
+
+        Args:
+            predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+            targets (:obj:`torch.Tensor`): The ground truth.
+
+        Returns:
+            float: The batch's accuracy.
+        """
+        predictions, targets = self._check_shapes(predictions, targets)
+
+        distances = pairwise_distance(predictions, targets, p=self._p, eps=self._epsilon)
+        _sum_of_distances = torch.sum(distances).item()
+        _num_examples = targets.shape[0]
+
+        if _num_examples == 0:
+            raise ValueError('MeanAbsoluteError must have at least one example before it can be computed.')
+
+        return _sum_of_distances / _num_examples
+
+
+class DiceCoefficient(Metric):
+    """Metric defining the commonly used Dice Coefficient."""
+
+    def __init__(self, epsilon=1e-6, ignore_index=None):
+        """Class constructor."""
+        super().__init__()
+        self._epsilon = epsilon
+        self._ignore_index = ignore_index
+
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Compute Dice coefficient.
+
+       Args:
+            predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+            targets (:obj:`torch.Tensor`): The ground truth.
+
+        Returns:
+            float: The batch's Dice coefficient.
+        """
+        predictions, targets = self._check_shapes(predictions, targets)
+
+
+class MeanIOU(Metric):
+    """Calculate the Mean IOU"""
+
+    def __init__(self, skip_channels=None, ignore_index=None):
+        """Class constructor."""
+        super().__init__()
+        self._skip_channels = skip_channels
+        self._ignore_index = ignore_index
+
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Compute Mean Intersection Over Union.
+
+        Args:
+            predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+            targets (:obj:`torch.Tensor`): The ground truth.
+
+        Returns:
+            float: The batch's mean IOU.
+        """
+        predictions, targets = self._check_shapes(predictions, targets)
+
+
+class Precision(BasePrecisionRecall):
+    def __init__(self, average=False, is_multilabel=False):
+        super(Precision, self).__init__(average=average, is_multilabel=is_multilabel)
+
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Compute Precision.
+
+        Args:
+            predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+            targets (:obj:`torch.Tensor`): The ground truth.
+
+        Returns:
+            float: The batch's precision.
+        """
+        predictions, targets = self._check_shapes(predictions, targets)
+
+        self._select_metric_type(predictions, targets)
+
+        if self._type == "binary":
+            predictions = predictions.view(-1)
+            targets = targets.view(-1)
+        elif self._type == "multiclass":
+            num_classes = predictions.size(1)
+            if targets.max() + 1 > num_classes:
+                raise ValueError("predictions contains less classes than targets. Number of predicted classes is {}"
+                                 " and element in targets has invalid class = {}.".format(num_classes,
+                                                                                          targets.max().item() + 1))
+            targets = to_onehot(targets.view(-1), num_classes=num_classes)
+            indices = torch.argmax(predictions, dim=1).view(-1)
+            predictions = to_onehot(indices, num_classes=num_classes)
+        elif self._type == "multilabel":
+            # if targets, predictions shape is (N, C, ...) -> (C, N x ...)
+            num_classes = predictions.size(1)
+            predictions = torch.transpose(predictions, 1, 0).reshape(num_classes, -1)
+            targets = torch.transpose(targets, 1, 0).reshape(num_classes, -1)
+
+        targets = targets.type_as(predictions)
+        correct = targets * predictions
+        all_positives = predictions.sum(dim=0).type(torch.DoubleTensor)  # Convert from int cuda/cpu to double cpu
+
+        if correct.sum() == 0:
+            true_positives = torch.zeros_like(all_positives)
+        else:
+            true_positives = correct.sum(dim=0)
+        # Convert from int cuda/cpu to double cpu
+        # We need double precision for the division true_positives / all_positives
+        true_positives = true_positives.type(torch.DoubleTensor)
+
+        if self._type == "multilabel":
+            if not self._average:
+                self._true_positives = torch.cat([self._true_positives, true_positives], dim=0)
+                self._positives = torch.cat([self._positives, all_positives], dim=0)
+            else:
+                self._true_positives += torch.sum(true_positives / (all_positives + self.eps))
+                self._positives += len(all_positives)
+        else:
+            self._true_positives = true_positives
+            self._positives = all_positives
+
+        if not (isinstance(self._positives, torch.Tensor) or self._positives > 0):
+            raise ValueError("{} must have at least one example before"
+                             " it can be computed.".format(self.__class__.__name__))
+
+        result = self._true_positives / (self._positives + self._epsilon)
+
+        if self._average:
+            return result.mean().item()
+        else:
+            return result
+
+
+class Recall(BasePrecisionRecall):
+    def __init__(self, average=False, is_multilabel=False):
+        super(Recall, self).__init__(average=average, is_multilabel=is_multilabel)
+
+    def compute(self, predictions: torch.Tensor, targets: torch.Tensor) -> float:
+        """Compute Recall.
+
+        Args:
+            predictions (:obj:`torch.Tensor`): The model's predictions on which the metric has to be computed.
+            targets (:obj:`torch.Tensor`): The ground truth.
+
+        Returns:
+            float: The batch's recall.
+        """
+        predictions, targets = self._check_shapes(predictions, targets)
+        self._select_metric_type(predictions, targets)
+
+        if self._type == "binary":
+            predictions = predictions.view(-1)
+            targets = targets.view(-1)
+        elif self._type == "multiclass":
+            num_classes = predictions.size(1)
+            if targets.max() + 1 > num_classes:
+                raise ValueError("predictions contains less classes than targets. Number of predicted classes is {}"
+                                 " and element in targets has invalid class = {}.".format(num_classes,
+                                                                                          targets.max().item() + 1))
+            targets = to_onehot(targets.view(-1), num_classes=num_classes)
+            indices = torch.argmax(predictions, dim=1).view(-1)
+            predictions = to_onehot(indices, num_classes=num_classes)
+        elif self._type == "multilabel":
+            # if targets, predictions shape is (N, C, ...) -> (C, N x ...)
+            num_classes = predictions.size(1)
+            predictions = torch.transpose(predictions, 1, 0).reshape(num_classes, -1)
+            targets = torch.transpose(targets, 1, 0).reshape(num_classes, -1)
+
+        targets = targets.type_as(predictions)
+        correct = targets * predictions
+        actual_positives = targets.sum(dim=0).type(torch.DoubleTensor)  # Convert from int cuda/cpu to double cpu
+
+        if correct.sum() == 0:
+            true_positives = torch.zeros_like(actual_positives)
+        else:
+            true_positives = correct.sum(dim=0)
+
+        # Convert from int cuda/cpu to double cpu
+        # We need double precision for the division true_positives / actual_positives
+        true_positives = true_positives.type(torch.DoubleTensor)
+
+        if self._type == "multilabel":
+            if not self._average:
+                self._true_positives = torch.cat([self._true_positives, true_positives], dim=0)
+                self._positives = torch.cat([self._positives, actual_positives], dim=0)
+            else:
+                self._true_positives += torch.sum(true_positives / (actual_positives + self.eps))
+                self._positives += len(actual_positives)
+        else:
+            self._true_positives += true_positives
+            self._positives += actual_positives
+
+        if not (isinstance(self._positives, torch.Tensor) or self._positives > 0):
+            raise ValueError("{} must have at least one example before"
+                             " it can be computed.".format(self.__class__.__name__))
+
+        result = self._true_positives / (self._positives + self.eps)
+
+        if self._average:
+            return result.mean().item()
+        else:
+            return result

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -14,3 +14,1474 @@
 # limitations under the License.
 # ==============================================================================
 
+
+import unittest
+import torch
+
+from hamcrest import *
+from metrics.metrics import Accuracy, MeanSquaredError, MeanAbsoluteError, RootMeanSquaredError, MeanPairwiseDistance, \
+    TopKCategoricalAccuracy, Precision, Recall
+from sklearn.metrics import accuracy_score, precision_score
+
+
+class MetricTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @staticmethod
+    def test_check_shapes():
+        # Instanciate an Accuracy metric.
+        the_metric = Accuracy()
+
+        predictions = torch.randint(0, 2, size=(10, 1, 28, 28)).type(torch.LongTensor)
+        targets = torch.randint(0, 2, size=(10, 28, 28)).type(torch.LongTensor)
+
+        # Sanity check on test's inputs.
+        assert_that(predictions.shape, is_((10, 1, 28, 28)))
+        assert_that(targets.shape, is_((10, 28, 28)))
+
+        assert_that(the_metric._check_shapes(predictions, targets), not raises(ValueError))
+
+        predictions = torch.randint(0, 2, size=(10, 28, 28)).type(torch.LongTensor)
+        targets = torch.randint(0, 2, size=(10, 1, 28, 28)).type(torch.LongTensor)
+
+        # Sanity check on test's inputs.
+        assert_that(predictions.shape, is_((10, 28, 28)))
+        assert_that(targets.shape, is_((10, 1, 28, 28)))
+
+        assert_that(the_metric._check_shapes(predictions, targets), not raises(ValueError))
+
+
+class AccuracyMetricTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @staticmethod
+    def test_binary_wrong_inputs():
+        the_metric = Accuracy()
+
+        assert_that(calling(the_metric.compute).with_args(torch.randint(0, 2, size=(10,)).type(torch.LongTensor),
+                                                          torch.arange(0, 10).type(torch.LongTensor)), raises(
+            ValueError))
+
+        assert_that(calling(the_metric.compute).with_args(torch.rand(10, 1),
+                                                          torch.randint(0, 2, size=(10,)).type(torch.LongTensor)),
+                    raises(ValueError))
+
+        assert_that(calling(the_metric.compute).with_args(torch.randint(0, 2, size=(10,)).type(torch.LongTensor),
+                                                          torch.randint(0, 2, size=(10, 5)).type(torch.LongTensor)),
+                    raises(ValueError))
+
+        assert_that(calling(the_metric.compute).with_args(torch.randint(0, 2, size=(10, 5, 6)).type(torch.LongTensor),
+                                                          torch.randint(0, 2, size=(10,)).type(torch.LongTensor)),
+                    raises(ValueError))
+
+        assert_that(calling(the_metric.compute).with_args(torch.randint(0, 2, size=(10,)).type(torch.LongTensor),
+                                                          torch.randint(0, 2, size=(10, 5, 6)).type(torch.LongTensor)),
+                    raises(ValueError))
+
+    @staticmethod
+    def test_binary_input_N():
+        # Binary accuracy on input of shape (N, 1) or (N, )
+        def _test():
+            # Test with shape (N, 1)
+            the_metric = Accuracy()
+            predictions = torch.randint(0, 2, size=(10, 1)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(10,)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with shape (N, )
+            the_metric = Accuracy()
+            predictions = torch.randint(0, 2, size=(10,)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(10,)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with batches
+            the_metric = Accuracy()
+            predictions = torch.randint(0, 2, size=(100,)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(100,)).type(torch.LongTensor)
+            n_iters = 16
+            batch_size = targets.shape[0] // (n_iters + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_targets = targets[idx: idx + batch_size].numpy().ravel()
+                np_predictions = predictions[idx: idx + batch_size].numpy().ravel()
+                assert_that(the_metric._type, is_("binary"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # Check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    @staticmethod
+    def test_binary_input_NL():
+        # Binary accuracy on input of shape (N, L)
+        def _test():
+            the_metric = Accuracy()
+            predictions = torch.randint(0, 2, size=(10, 5)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(10, 5)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            the_metric = Accuracy()
+            predictions = torch.randint(0, 2, size=(10, 1, 5)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(10, 1, 5)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with batches.
+            the_metric = Accuracy()
+            predictions = torch.randint(0, 2, size=(100, 8)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(100, 8)).type(torch.LongTensor)
+            n_iters = 16
+            batch_size = targets.shape[0] // (n_iters + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_targets = targets[idx: idx + batch_size].numpy().ravel()
+                np_predictions = predictions[idx: idx + batch_size].numpy().ravel()
+                assert_that(the_metric._type, is_("binary"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    @staticmethod
+    def test_binary_input_NHW():
+        # Binary accuracy on input of shape (N, H, W, ...)
+        def _test():
+            the_metric = Accuracy()
+            predictions = torch.randint(0, 2, size=(4, 12, 10)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(4, 12, 10)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            the_metric = Accuracy()
+            predictions = torch.randint(0, 2, size=(4, 1, 12, 10)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(4, 1, 12, 10)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with batches
+            the_metric = Accuracy()
+            predictions = torch.randint(0, 2, size=(100, 1, 8, 8)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(100, 8, 8)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_targets = targets[idx: idx + batch_size].numpy().ravel()
+                np_predictions = predictions[idx: idx + batch_size].numpy().ravel()
+                assert_that(the_metric._type, is_("binary"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    @staticmethod
+    def test_multiclass_wrong_inputs():
+        # Incompatible shapes
+        the_metric = Accuracy()
+        assert_that(calling(the_metric.compute).with_args(torch.rand(10, 5, 4),
+                                                          torch.randint(0, 2, size=(10,)).type(torch.LongTensor)),
+                    raises(ValueError))
+
+        # incompatible shapes
+        the_metric = Accuracy()
+        assert_that(calling(the_metric.compute).with_args(torch.rand(10, 5, 6),
+                                                          torch.randint(0, 5, size=(10, 5)).type(torch.LongTensor)),
+                    raises(ValueError))
+
+        # incompatible shapes
+        the_metric = Accuracy()
+        assert_that(calling(the_metric.compute).with_args(torch.rand(10),
+                                                          torch.randint(0, 5, size=(10, 5, 6)).type(torch.LongTensor)),
+                    raises(ValueError))
+
+    @staticmethod
+    def test_multiclass_input_N():
+        # Multiclass input data of shape (N, ) and (N, C)
+        def _test():
+            the_metric = Accuracy()
+            predictions = torch.rand(10, 4)
+            targets = torch.randint(0, 4, size=(10,)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy().argmax(axis=1).ravel()
+            np_targets = targets.numpy().ravel()
+            assert_that(the_metric._type, is_("multiclass"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            the_metric = Accuracy()
+            predictions = torch.rand(4, 10)
+            targets = torch.randint(0, 10, size=(4, 1)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy().argmax(axis=1).ravel()
+            np_targets = targets.numpy().ravel()
+            assert_that(the_metric._type, is_("multiclass"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            the_metric = Accuracy()
+            predictions = torch.rand(4, 2)
+            targets = torch.randint(0, 2, size=(4, 1)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy().argmax(axis=1).ravel()
+            np_targets = targets.numpy().ravel()
+            assert_that(the_metric._type, is_("multiclass"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with batches.
+            the_metric = Accuracy()
+            predictions = torch.rand(100, 5)
+            targets = torch.randint(0, 5, size=(100,)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_targets = targets[idx: idx + batch_size].numpy().ravel()
+                np_predictions = predictions[idx: idx + batch_size].numpy().argmax(axis=1).ravel()
+                assert_that(the_metric._type, is_("multiclass"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # Check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    @staticmethod
+    def test_multiclass_input_NL():
+        # Multiclass input data of shape (N, L) and (N, C, L)
+        def _test():
+            # Test with shape (N, C, L)
+            the_metric = Accuracy()
+            predictions = torch.rand(10, 4, 5)
+            targets = torch.randint(0, 4, size=(10, 5)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy().argmax(axis=1).ravel()
+            np_targets = targets.numpy().ravel()
+            assert_that(the_metric._type, is_("multiclass"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with shape (C, N, L)
+            the_metric = Accuracy()
+            predictions = torch.rand(4, 10, 5)
+            targets = torch.randint(0, 10, size=(4, 5)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy().argmax(axis=1).ravel()
+            np_targets = targets.numpy().ravel()
+            assert_that(the_metric._type, is_("multiclass"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with batches
+            the_metric = Accuracy()
+            predictions = torch.rand(100, 9, 7)
+            targets = torch.randint(0, 9, size=(100, 7)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_targets = targets[idx: idx + batch_size].numpy().ravel()
+                np_predictions = predictions[idx: idx + batch_size].numpy().argmax(axis=1).ravel()
+                assert_that(the_metric._type, is_("multiclass"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # Check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    @staticmethod
+    def test_multiclass_input_NHW():
+        # Multiclass input data of shape (N, H, W, ...) and (N, C, H, W, ...)
+        def _test():
+            # Test with shape (N, H, W, ...)
+            the_metric = Accuracy()
+            predictions = torch.rand(4, 5, 12, 10)
+            targets = torch.randint(0, 5, size=(4, 12, 10)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy().argmax(axis=1).ravel()
+            np_targets = targets.numpy().ravel()
+            assert_that(the_metric._type, is_("multiclass"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with shape (N, C, H, W, ...)
+            the_metric = Accuracy()
+            predictions = torch.rand(4, 5, 10, 12, 8)
+            targets = torch.randint(0, 5, size=(4, 10, 12, 8)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy().argmax(axis=1).ravel()
+            np_targets = targets.numpy().ravel()
+            assert_that(the_metric._type, is_("multiclass"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with batches
+            the_metric = Accuracy()
+            predictions = torch.rand(100, 3, 8, 8)
+            targets = torch.randint(0, 3, size=(100, 8, 8)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_targets = targets[idx: idx + batch_size].numpy().ravel()
+                np_predictions = predictions[idx: idx + batch_size].numpy().argmax(axis=1).ravel()
+                assert_that(the_metric._type, is_("multiclass"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # Check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    @staticmethod
+    def test_multiclass_input_NHWD():
+        # Multiclass input data of shape (N, H, W, D, ...) and (N, C, H, W, D, ...)
+        def _test():
+            # Test with shape (N, H, W, D, ...)
+            the_metric = Accuracy()
+            predictions = torch.rand(4, 5, 12, 10, 14)
+            targets = torch.randint(0, 5, size=(4, 12, 10, 14)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy().argmax(axis=1).ravel()
+            np_targets = targets.numpy().ravel()
+            assert_that(the_metric._type, is_("multiclass"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with shape (N, C, H, W, D, ...)
+            the_metric = Accuracy()
+            predictions = torch.rand(4, 5, 10, 12, 8, 14)
+            targets = torch.randint(0, 5, size=(4, 10, 12, 8, 14)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy().argmax(axis=1).ravel()
+            np_targets = targets.numpy().ravel()
+            assert_that(the_metric._type, is_("multiclass"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with batches
+            the_metric = Accuracy()
+            predictions = torch.rand(100, 3, 8, 8, 8)
+            targets = torch.randint(0, 3, size=(100, 8, 8, 8)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_targets = targets[idx: idx + batch_size].numpy().ravel()
+                np_predictions = predictions[idx: idx + batch_size].numpy().argmax(axis=1).ravel()
+                assert_that(the_metric._type, is_("multiclass"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # Check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    @staticmethod
+    def to_numpy_multilabel(y):
+        # reshapes input array to (N x ..., C)
+        y = y.transpose(1, 0).numpy()
+        num_classes = y.shape[0]
+        y = y.reshape((num_classes, -1)).transpose(1, 0)
+        return y
+
+    @staticmethod
+    def test_multilabel_wrong_inputs():
+        the_metric = Accuracy(is_multilabel=True)
+        assert_that(
+            calling(the_metric.compute).with_args(torch.randint(0, 2, size=(10,)),
+                                                  torch.randint(0, 2, size=(10,)).type(torch.LongTensor)),
+            raises(ValueError))
+
+        the_metric = Accuracy(is_multilabel=True)
+        assert_that(
+            calling(the_metric.compute).with_args(torch.rand(10, 5),
+                                                  torch.randint(0, 2, size=(10, 5)).type(torch.LongTensor)),
+            raises(ValueError))
+
+        the_metric = Accuracy(is_multilabel=True)
+        assert_that(
+            calling(the_metric.compute).with_args(torch.randint(0, 5, size=(10, 5, 6)), torch.rand(10)),
+            raises(ValueError))
+
+    @staticmethod
+    def test_multilabel_input_N():
+        # Multilabel input data of shape (N, C, ...) and (N, C, ...)
+
+        def _test():
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(10, 4))
+            targets = torch.randint(0, 2, size=(10, 4)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy()
+            np_targets = targets.numpy()
+            assert_that(the_metric._type, is_("multilabel"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(50, 7)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(50, 7)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = predictions.numpy()
+            np_targets = targets.numpy()
+            assert_that(the_metric._type, is_("multilabel"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with batches
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(100, 4))
+            targets = torch.randint(0, 2, size=(100, 4)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_targets = targets[idx: idx + batch_size].numpy()
+                np_predictions = predictions[idx: idx + batch_size].numpy()
+                assert_that(the_metric._type, is_("multilabel"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # Check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    def test_multilabel_input_NL(self):
+        # Multilabel input data of shape (N, C, L, ...) and (N, C, L, ...)
+        def _test():
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(10, 4, 5))
+            targets = torch.randint(0, 2, size=(10, 4, 5)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = self.to_numpy_multilabel(predictions)  # (N, C, L, ...) -> (N * L * ..., C)
+            np_targets = self.to_numpy_multilabel(targets)  # (N, C, L, ...) -> (N * L ..., C)
+            assert_that(the_metric._type, is_("multilabel"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(4, 10, 8)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(4, 10, 8)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = self.to_numpy_multilabel(predictions)  # (N, C, L, ...) -> (N * L * ..., C)
+            np_targets = self.to_numpy_multilabel(targets)  # (N, C, L, ...) -> (N * L ..., C)
+            assert_that(the_metric._type, is_("multilabel"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # test with batches
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(100, 4, 5))
+            targets = torch.randint(0, 2, size=(100, 4, 5)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_predictions = self.to_numpy_multilabel(
+                    predictions[idx: idx + batch_size])  # (N, C, L, ...) -> (N * L * ..., C)
+                np_targets = self.to_numpy_multilabel(
+                    targets[idx: idx + batch_size])  # (N, C, L, ...) -> (N * L ..., C)
+                assert_that(the_metric._type, is_("multilabel"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # Check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    def test_multilabel_input_NHW(self):
+        # Multilabel input data of shape (N, C, H, W, ...) and (N, C, H, W, ...)
+
+        def _test():
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(4, 5, 12, 10))
+            targets = torch.randint(0, 2, size=(4, 5, 12, 10)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = self.to_numpy_multilabel(predictions)  # (N, C, H, W, ...) -> (N * H * W ..., C)
+            np_targets = self.to_numpy_multilabel(targets)  # (N, C, H, W, ...) -> (N * H * W ..., C)
+            assert_that(the_metric._type, is_("multilabel"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(4, 10, 12, 8)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(4, 10, 12, 8)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = self.to_numpy_multilabel(predictions)  # (N, C, H, W, ...) -> (N * H * W ..., C)
+            np_targets = self.to_numpy_multilabel(targets)  # (N, C, H, W, ...) -> (N * H * W ..., C)
+            assert_that(the_metric._type, is_("multilabel"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with batches
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(100, 5, 12, 10))
+            targets = torch.randint(0, 2, size=(100, 5, 12, 10)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_predictions = self.to_numpy_multilabel(
+                    predictions[idx: idx + batch_size])  # (N, C, L, ...) -> (N * L * ..., C)
+                np_targets = self.to_numpy_multilabel(
+                    targets[idx: idx + batch_size])  # (N, C, L, ...) -> (N * L ..., C)
+                assert_that(the_metric._type, is_("multilabel"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    def test_multilabel_input_NHWD(self):
+        # Multilabel input data of shape (N, C, H, W, D, ...) and (N, C, H, W, D, ...)
+
+        def _test():
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(4, 5, 12, 10, 14))
+            targets = torch.randint(0, 2, size=(4, 5, 12, 10, 14)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = self.to_numpy_multilabel(predictions)  # (N, C, H, W, ...) -> (N * H * W ..., C)
+            np_targets = self.to_numpy_multilabel(targets)  # (N, C, H, W, ...) -> (N * H * W ..., C)
+            assert_that(the_metric._type, is_("multilabel"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(4, 10, 12, 8, 14)).type(torch.LongTensor)
+            targets = torch.randint(0, 2, size=(4, 10, 12, 8, 14)).type(torch.LongTensor)
+            accuracy = the_metric.compute(predictions, targets)
+            np_predictions = self.to_numpy_multilabel(predictions)  # (N, C, H, W, ...) -> (N * H * W ..., C)
+            np_targets = self.to_numpy_multilabel(targets)  # (N, C, H, W, ...) -> (N * H * W ..., C)
+            assert_that(the_metric._type, is_("multilabel"))
+            assert_that(accuracy, is_(float))
+            assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+            # Test with batches
+            the_metric = Accuracy(is_multilabel=True)
+            predictions = torch.randint(0, 2, size=(100, 5, 12, 10, 14))
+            targets = torch.randint(0, 2, size=(100, 5, 12, 10, 14)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                accuracy = the_metric.compute(predictions[idx: idx + batch_size], targets[idx: idx + batch_size])
+                np_predictions = self.to_numpy_multilabel(
+                    predictions[idx: idx + batch_size])  # (N, C, L, ...) -> (N * L * ..., C)
+                np_targets = self.to_numpy_multilabel(
+                    targets[idx: idx + batch_size])  # (N, C, L, ...) -> (N * L ..., C)
+                assert_that(the_metric._type, is_("multilabel"))
+                assert_that(accuracy, is_(float))
+                assert_that(accuracy_score(np_targets, np_predictions), equal_to(accuracy))
+
+        # check multiple random inputs as random exact occurencies are rare
+        for _ in range(10):
+            _test()
+
+    @staticmethod
+    def test_incorrect_type():
+        # Instanciate an Accuracy metric.
+        the_metric = Accuracy()
+
+        # Start as binary data
+        predictions = torch.randint(0, 2, size=(4,))
+        targets = torch.ones(4).type(torch.LongTensor)
+        the_metric.compute(predictions, targets)
+
+        # And add a multiclass data
+        predictions = torch.rand(4, 4)
+        targets = torch.ones(4).type(torch.LongTensor)
+
+        assert_that(calling(the_metric.compute).with_args(predictions, targets), raises(RuntimeError))
+
+
+class MeanSquareErrorMetricTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @staticmethod
+    def test_compute():
+        the_metric = MeanSquaredError()
+        predictions = torch.Tensor([[2.0], [-2.0]])
+        target = torch.zeros(2)
+        mse = the_metric.compute(predictions, target)
+        assert_that(mse, is_(float))
+        assert_that(mse, equal_to(4.0))
+
+        the_metric = MeanSquaredError()
+        predictions = torch.Tensor([[3.0], [-3.0]])
+        target = torch.zeros(2)
+        mse = the_metric.compute(predictions, target)
+        assert_that(mse, is_(float))
+        assert_that(mse, equal_to(9.0))
+
+
+class RootMeanSquareErrorMetricTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @staticmethod
+    def test_compute():
+        the_metric = RootMeanSquaredError()
+        predictions = torch.Tensor([[2.0], [-2.0]])
+        targets = torch.zeros(2)
+        rmse = the_metric.compute(predictions, targets)
+        assert_that(rmse, is_(float))
+        assert_that(rmse, equal_to(2.0))
+
+        the_metric = RootMeanSquaredError()
+        predictions = torch.Tensor([[3.0], [-3.0]])
+        targets = torch.zeros(2)
+        rmse = the_metric.compute(predictions, targets)
+        assert_that(rmse, is_(float))
+        assert_that(rmse, equal_to(3.0))
+
+
+class MeanAbsoluteErrorMetricTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    @staticmethod
+    def test_compute():
+        the_metric = MeanAbsoluteError()
+        predictions = torch.Tensor([[2.0], [-2.0]])
+        targets = torch.zeros(2)
+        mae = the_metric.compute(predictions, targets)
+        assert_that(mae, is_(float))
+        assert_that(mae, equal_to(2.0))
+
+        the_metric = MeanAbsoluteError()
+        predictions = torch.Tensor([[3.0], [-3.0]])
+        targets = torch.zeros(2)
+        mae = the_metric.compute(predictions, targets)
+        assert_that(mae, is_(float))
+        assert_that(mae, equal_to(3.0))
+
+
+class MeanPairwiseDistanceMetricTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @staticmethod
+    def test_compute():
+        the_metric = MeanPairwiseDistance()
+        predictions = torch.Tensor([[3.0, 4.0], [-3.0, -4.0]])
+        targets = torch.zeros(2, 2)
+        mpd = the_metric.compute(predictions, targets)
+        assert_that(mpd, is_(float))
+        assert_that(mpd, equal_to(5.0))
+
+        the_metric = MeanPairwiseDistance()
+        predictions = torch.Tensor([[4.0, 4.0, 4.0, 4.0], [-4.0, -4.0, -4.0, -4.0]])
+        targets = torch.zeros(2, 4)
+        mpd = the_metric.compute(predictions, targets)
+        assert_that(mpd, is_(float))
+        assert_that(mpd, equal_to(8.0))
+
+
+class TopKCategoritcalAccuracyMetricTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @staticmethod
+    def test_compute():
+        the_metric = TopKCategoricalAccuracy(2)
+        predictions = torch.FloatTensor([[0.2, 0.4, 0.6, 0.8], [0.8, 0.6, 0.4, 0.2]])
+        targets = torch.ones(2).type(torch.LongTensor)
+        top_k_accuracy = the_metric.compute(predictions, targets)
+        assert_that(top_k_accuracy, is_(float))
+        assert_that(top_k_accuracy, equal_to(0.50))
+
+        the_metric = TopKCategoricalAccuracy(2)
+        predictions = torch.FloatTensor([[0.4, 0.8, 0.2, 0.6], [0.8, 0.6, 0.4, 0.2]])
+        target = torch.ones(2).type(torch.LongTensor)
+        top_k_accuracy = the_metric.compute(predictions, target)
+        assert_that(top_k_accuracy, is_(float))
+        assert_that(top_k_accuracy, equal_to(1.0))
+
+
+class PrecisionMetricTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @staticmethod
+    def test_binary_wrong_inputs():
+        the_metric = Precision()
+
+        assert_that(calling(the_metric.compute).with_args(torch.randint(0, 2, size=(10,)).type(torch.LongTensor),
+                                                          torch.arange(0, 10).type(torch.LongTensor)),
+                    raises(ValueError))
+
+        assert_that(calling(the_metric.compute).with_args(torch.rand(10, 1),
+                                                          torch.randint(0, 2, size=(10,)).type(torch.LongTensor)),
+                    raises(ValueError))
+
+        assert_that(calling(the_metric.compute).with_args(torch.randint(0, 2, size=(10,)).type(torch.LongTensor),
+                                                          torch.randint(0, 2, size=(10, 5)).type(torch.LongTensor)),
+                    raises(ValueError))
+
+        assert_that(calling(the_metric.compute).with_args(torch.randint(0, 2, size=(10, 5, 6)).type(torch.LongTensor),
+                                                          torch.randint(0, 2, size=(10,)).type(torch.LongTensor)),
+                    raises(ValueError))
+
+        assert_that(calling(the_metric.compute).with_args(torch.randint(0, 2, size=(10,)).type(torch.LongTensor),
+                                                          torch.randint(0, 2, size=(10, 5, 6)).type(
+                                                              torch.LongTensor)),
+                    raises(ValueError))
+
+    @staticmethod
+    def test_binary_input_N():
+        # Binary accuracy on input of shape (N, 1) or (N, )
+
+        def _test(average):
+            the_metric = Precision(average=average)
+            predictions = torch.randint(0, 2, size=(10, 1))
+            targets = torch.randint(0, 2, size=(10,)).type(torch.LongTensor)
+            precision = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(precision, is_(float) if average else is_(torch.Tensor))
+            pr_compute = the_metric.compute(predictions, targets) if average else the_metric.compute(predictions,
+                                                                                                     targets).numpy()
+            assert_that(precision_score(np_targets, np_predictions), equal_to(pr_compute))
+
+            the_metric = Precision(average=average)
+            predictions = torch.randint(0, 2, size=(10,))
+            targets = torch.randint(0, 2, size=(10,)).type(torch.LongTensor)
+            precision = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(precision, is_(float) if average else is_(torch.Tensor))
+            pr_compute = the_metric.compute(predictions, targets) if average else the_metric.compute(predictions,
+                                                                                                     targets).numpy()
+            assert_that(precision_score(np_targets, np_predictions), equal_to(pr_compute))
+
+            the_metric = Precision(average=average)
+            predictions = torch.Tensor([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.51])
+            predictions = torch.round(predictions)
+            targets = torch.randint(0, 2, size=(10,)).type(torch.LongTensor)
+            precision = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(precision, is_(float) if average else is_(torch.Tensor))
+            pr_compute = the_metric.compute(predictions, targets) if average else the_metric.compute(predictions,
+                                                                                                     targets).numpy()
+            assert_that(precision_score(np_targets, np_predictions), equal_to(pr_compute))
+
+            # Test with batches.
+            the_metric = Precision(average=average)
+            predictions = torch.randint(0, 2, size=(100,))
+            targets = torch.randint(0, 2, size=(100,)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                precision = the_metric.compute(predictions[idx:idx + batch_size], targets[idx:idx + batch_size])
+                np_targets = targets[idx:idx + batch_size].numpy().ravel()
+                np_predictions = predictions[idx:idx + batch_size].numpy().ravel()
+                assert_that(the_metric._type, is_("binary"))
+                assert_that(precision, is_(float) if average else is_(torch.Tensor))
+                pr_compute = the_metric.compute(predictions[idx:idx + batch_size],
+                                                targets[idx:idx + batch_size]) if average else the_metric.compute(
+                    predictions[idx:idx + batch_size],
+                    targets[idx:idx + batch_size]).numpy()
+                assert_that(precision_score(np_targets, np_predictions), equal_to(pr_compute))
+
+        for _ in range(5):
+            _test(average=True)
+            _test(average=False)
+
+    @staticmethod
+    def test_binary_input_NL():
+        # Binary accuracy on input of shape (N, L)
+
+        def _test(average):
+            the_metric = Precision(average=average)
+            predictions = torch.randint(0, 2, size=(10, 5))
+            targets = torch.randint(0, 2, size=(10, 5)).type(torch.LongTensor)
+            precision = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(precision, is_(float) if average else is_(torch.Tensor))
+            pr_compute = the_metric.compute(predictions, targets) if average else the_metric.compute(predictions,
+                                                                                                     targets).numpy()
+            assert_that(precision_score(np_targets, np_predictions), equal_to(pr_compute))
+
+            the_metric = Precision(average=average)
+            predictions = torch.randint(0, 2, size=(10, 1, 5))
+            targets = torch.randint(0, 2, size=(10, 1, 5)).type(torch.LongTensor)
+            precision = the_metric.compute(predictions, targets)
+            np_targets = targets.numpy().ravel()
+            np_predictions = predictions.numpy().ravel()
+            assert_that(the_metric._type, is_("binary"))
+            assert_that(precision, is_(float) if average else is_(torch.Tensor))
+            pr_compute = the_metric.compute(predictions, targets) if average else the_metric.compute(predictions,
+                                                                                                     targets).numpy()
+            assert_that(precision_score(np_targets, np_predictions), equal_to(pr_compute))
+
+            # Test with batches
+            the_metric = Precision(average=average)
+            predictions = torch.randint(0, 2, size=(100, 5))
+            targets = torch.randint(0, 2, size=(100, 1, 5)).type(torch.LongTensor)
+            batch_size = 16
+            n_iters = targets.shape[0] // (batch_size + 1)
+
+            for i in range(n_iters):
+                idx = i * batch_size
+                precision = the_metric.compute(predictions[idx:idx + batch_size], targets[idx:idx + batch_size])
+                np_targets = targets[idx:idx + batch_size].numpy().ravel()
+                np_predictions = predictions[idx:idx + batch_size].numpy().ravel()
+                assert_that(the_metric._type, is_("binary"))
+                assert_that(precision, is_(float) if average else is_(torch.Tensor))
+                pr_compute = the_metric.compute(predictions[idx:idx + batch_size],
+                                                targets[idx:idx + batch_size]) if average else the_metric.compute(
+                    predictions[idx:idx + batch_size],
+                    targets[idx:idx + batch_size]).numpy()
+                assert_that(precision_score(np_targets, np_predictions), equal_to(pr_compute))
+
+        for _ in range(5):
+            _test(average=True)
+            _test(average=False)
+
+
+#
+#
+# def test_binary_input_NHW():
+#     # Binary accuracy on input of shape (N, H, W)
+#
+#     def _test(average):
+#         pr = Precision(average=average)
+#
+#         predictions = torch.randint(0, 2, size=(10, 12, 10))
+#         y = torch.randint(0, 2, size=(10, 12, 10)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         np_targets = y.numpy().ravel()
+#         np_predictions = predictions.numpy().ravel()
+#         assert pr._type == 'binary'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         assert precision_score(np_targets, np_predictions, average='binary') == pytest.approx(pr_compute)
+#
+#         pr.reset()
+#         predictions = torch.randint(0, 2, size=(10, 1, 12, 10))
+#         y = torch.randint(0, 2, size=(10, 1, 12, 10)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         np_targets = y.numpy().ravel()
+#         np_predictions = predictions.numpy().ravel()
+#         assert pr._type == 'binary'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         assert precision_score(np_targets, np_predictions, average='binary') == pytest.approx(pr_compute)
+#
+#         pr = Precision(average=average)
+#         # Batched Updates
+#         pr.reset()
+#         predictions = torch.randint(0, 2, size=(100, 12, 10))
+#         y = torch.randint(0, 2, size=(100, 1, 12, 10)).type(torch.LongTensor)
+#
+#         batch_size = 16
+#         n_iters = y.shape[0] // batch_size + 1
+#
+#         for i in range(n_iters):
+#             idx = i * batch_size
+#             pr.update((predictions[idx:idx + batch_size], y[idx:idx + batch_size]))
+#
+#         np_targets = y.numpy().ravel()
+#         np_predictions = predictions.numpy().ravel()
+#         assert pr._type == 'binary'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         assert precision_score(np_targets, np_predictions, average='binary') == pytest.approx(pr_compute)
+#
+#     for _ in range(5):
+#         _test(average=True)
+#         _test(average=False)
+#
+#
+# def test_multiclass_wrong_inputs():
+#     pr = Precision()
+#
+#     with pytest.raises(ValueError):
+#         # incompatible shapes
+#         pr.update((torch.rand(10, 5, 4), torch.randint(0, 2, size=(10,)).type(torch.LongTensor)))
+#
+#     with pytest.raises(ValueError):
+#         # incompatible shapes
+#         pr.update((torch.rand(10, 5, 6), torch.randint(0, 5, size=(10, 5)).type(torch.LongTensor)))
+#
+#     with pytest.raises(ValueError):
+#         # incompatible shapes
+#         pr.update((torch.rand(10), torch.randint(0, 5, size=(10, 5, 6)).type(torch.LongTensor)))
+#
+#     pr = Precision(average=True)
+#
+#     with pytest.raises(ValueError):
+#         # incompatible shapes between two updates
+#         pr.update((torch.rand(10, 5), torch.randint(0, 5, size=(10,)).type(torch.LongTensor)))
+#         pr.update((torch.rand(10, 6), torch.randint(0, 5, size=(10,)).type(torch.LongTensor)))
+#
+#     with pytest.raises(ValueError):
+#         # incompatible shapes between two updates
+#         pr.update((torch.rand(10, 5, 12, 14), torch.randint(0, 5, size=(10, 12, 14)).type(torch.LongTensor)))
+#         pr.update((torch.rand(10, 6, 12, 14), torch.randint(0, 5, size=(10, 12, 14)).type(torch.LongTensor)))
+#
+#     pr = Precision(average=False)
+#
+#     with pytest.raises(ValueError):
+#         # incompatible shapes between two updates
+#         pr.update((torch.rand(10, 5), torch.randint(0, 5, size=(10,)).type(torch.LongTensor)))
+#         pr.update((torch.rand(10, 6), torch.randint(0, 5, size=(10,)).type(torch.LongTensor)))
+#
+#     with pytest.raises(ValueError):
+#         # incompatible shapes between two updates
+#         pr.update((torch.rand(10, 5, 12, 14), torch.randint(0, 5, size=(10, 12, 14)).type(torch.LongTensor)))
+#         pr.update((torch.rand(10, 6, 12, 14), torch.randint(0, 5, size=(10, 12, 14)).type(torch.LongTensor)))
+#
+#
+# def test_multiclass_input_N():
+#     # Multiclass input data of shape (N, ) and (N, C)
+#
+#     def _test(average):
+#         pr = Precision(average=average)
+#         predictions = torch.rand(20, 6)
+#         y = torch.randint(0, 6, size=(20,)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         num_classes = predictions.shape[1]
+#         np_predictions = predictions.argmax(dim=1).numpy().ravel()
+#         np_targets = y.numpy().ravel()
+#         assert pr._type == 'multiclass'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         sk_average_parameter = 'macro' if average else None
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             sk_compute = precision_score(np_targets, np_predictions, labels=range(0, num_classes),
+#                                          average=sk_average_parameter)
+#             assert sk_compute == pytest.approx(pr_compute)
+#
+#         pr.reset()
+#         predictions = torch.rand(10, 4)
+#         y = torch.randint(0, 4, size=(10, 1)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         num_classes = predictions.shape[1]
+#         np_predictions = predictions.argmax(dim=1).numpy().ravel()
+#         np_targets = y.numpy().ravel()
+#         assert pr._type == 'multiclass'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         sk_average_parameter = 'macro' if average else None
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             sk_compute = precision_score(np_targets, np_predictions, labels=range(0, num_classes),
+#                                          average=sk_average_parameter)
+#             assert sk_compute == pytest.approx(pr_compute)
+#
+#         # 2-classes
+#         pr.reset()
+#         predictions = torch.rand(10, 2)
+#         y = torch.randint(0, 2, size=(10, 1)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         num_classes = predictions.shape[1]
+#         np_predictions = predictions.argmax(dim=1).numpy().ravel()
+#         np_targets = y.numpy().ravel()
+#         assert pr._type == 'multiclass'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         sk_average_parameter = 'macro' if average else None
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             sk_compute = precision_score(np_targets, np_predictions, labels=range(0, num_classes),
+#                                          average=sk_average_parameter)
+#             assert sk_compute == pytest.approx(pr_compute)
+#
+#         # Batched Updates
+#         pr.reset()
+#         predictions = torch.rand(100, 3)
+#         y = torch.randint(0, 3, size=(100,)).type(torch.LongTensor)
+#
+#         batch_size = 16
+#         n_iters = y.shape[0] // batch_size + 1
+#
+#         for i in range(n_iters):
+#             idx = i * batch_size
+#             pr.update((predictions[idx:idx + batch_size], y[idx:idx + batch_size]))
+#
+#         num_classes = predictions.shape[1]
+#         np_targets = y.numpy().ravel()
+#         np_predictions = predictions.argmax(dim=1).numpy().ravel()
+#         assert pr._type == 'multiclass'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         sk_average_parameter = 'macro' if average else None
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             sk_compute = precision_score(np_targets, np_predictions, labels=range(0, num_classes),
+#                                          average=sk_average_parameter)
+#             assert sk_compute == pytest.approx(pr_compute)
+#
+#     for _ in range(5):
+#         _test(average=True)
+#         _test(average=False)
+#
+#
+# def test_multiclass_input_NL():
+#     # Multiclass input data of shape (N, L) and (N, C, L)
+#
+#     def _test(average):
+#         pr = Precision(average=average)
+#
+#         predictions = torch.rand(10, 5, 8)
+#         y = torch.randint(0, 5, size=(10, 8)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         num_classes = predictions.shape[1]
+#         np_predictions = predictions.argmax(dim=1).numpy().ravel()
+#         np_targets = y.numpy().ravel()
+#         assert pr._type == 'multiclass'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         sk_average_parameter = 'macro' if average else None
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             sk_compute = precision_score(np_targets, np_predictions, labels=range(0, num_classes),
+#                                          average=sk_average_parameter)
+#             assert sk_compute == pytest.approx(pr_compute)
+#
+#         pr.reset()
+#         predictions = torch.rand(15, 10, 8)
+#         y = torch.randint(0, 10, size=(15, 8)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         num_classes = predictions.shape[1]
+#         np_predictions = predictions.argmax(dim=1).numpy().ravel()
+#         np_targets = y.numpy().ravel()
+#         assert pr._type == 'multiclass'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         sk_average_parameter = 'macro' if average else None
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             sk_compute = precision_score(np_targets, np_predictions, labels=range(0, num_classes),
+#                                          average=sk_average_parameter)
+#             assert sk_compute == pytest.approx(pr_compute)
+#
+#         # Batched Updates
+#         pr.reset()
+#         predictions = torch.rand(100, 8, 12)
+#         y = torch.randint(0, 8, size=(100, 12)).type(torch.LongTensor)
+#
+#         batch_size = 16
+#         n_iters = y.shape[0] // batch_size + 1
+#
+#         for i in range(n_iters):
+#             idx = i * batch_size
+#             pr.update((predictions[idx:idx + batch_size], y[idx:idx + batch_size]))
+#
+#         num_classes = predictions.shape[1]
+#         np_targets = y.numpy().ravel()
+#         np_predictions = predictions.argmax(dim=1).numpy().ravel()
+#         assert pr._type == 'multiclass'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         sk_average_parameter = 'macro' if average else None
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             sk_compute = precision_score(np_targets, np_predictions, labels=range(0, num_classes),
+#                                          average=sk_average_parameter)
+#             assert sk_compute == pytest.approx(pr_compute)
+#
+#     for _ in range(5):
+#         _test(average=True)
+#         _test(average=False)
+#
+#
+# def test_multiclass_input_NHW():
+#     # Multiclass input data of shape (N, H, W, ...) and (N, C, H, W, ...)
+#
+#     def _test(average):
+#         pr = Precision(average=average)
+#
+#         predictions = torch.rand(10, 5, 18, 16)
+#         y = torch.randint(0, 5, size=(10, 18, 16)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         num_classes = predictions.shape[1]
+#         np_predictions = predictions.argmax(dim=1).numpy().ravel()
+#         np_targets = y.numpy().ravel()
+#         assert pr._type == 'multiclass'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         sk_average_parameter = 'macro' if average else None
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             sk_compute = precision_score(np_targets, np_predictions, labels=range(0, num_classes),
+#                                          average=sk_average_parameter)
+#             assert sk_compute == pytest.approx(pr_compute)
+#
+#         pr.reset()
+#         predictions = torch.rand(10, 7, 20, 12)
+#         y = torch.randint(0, 7, size=(10, 20, 12)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         num_classes = predictions.shape[1]
+#         np_predictions = predictions.argmax(dim=1).numpy().ravel()
+#         np_targets = y.numpy().ravel()
+#         assert pr._type == 'multiclass'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         sk_average_parameter = 'macro' if average else None
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             sk_compute = precision_score(np_targets, np_predictions, labels=range(0, num_classes),
+#                                          average=sk_average_parameter)
+#             assert sk_compute == pytest.approx(pr_compute)
+#
+#         # Batched Updates
+#         pr.reset()
+#         predictions = torch.rand(100, 8, 12, 14)
+#         y = torch.randint(0, 8, size=(100, 12, 14)).type(torch.LongTensor)
+#
+#         batch_size = 16
+#         n_iters = y.shape[0] // batch_size + 1
+#
+#         for i in range(n_iters):
+#             idx = i * batch_size
+#             pr.update((predictions[idx:idx + batch_size], y[idx:idx + batch_size]))
+#
+#         num_classes = predictions.shape[1]
+#         np_targets = y.numpy().ravel()
+#         np_predictions = predictions.argmax(dim=1).numpy().ravel()
+#         assert pr._type == 'multiclass'
+#         assert isinstance(pr.compute(), float if average else torch.Tensor)
+#         pr_compute = pr.compute() if average else pr.compute().numpy()
+#         sk_average_parameter = 'macro' if average else None
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             sk_compute = precision_score(np_targets, np_predictions, labels=range(0, num_classes),
+#                                          average=sk_average_parameter)
+#             assert sk_compute == pytest.approx(pr_compute)
+#
+#     for _ in range(5):
+#         _test(average=True)
+#         _test(average=False)
+#
+#
+# def test_multilabel_wrong_inputs():
+#     pr = Precision(average=True, is_multilabel=True)
+#
+#     with pytest.raises(ValueError):
+#         # incompatible shapes
+#         pr.update((torch.randint(0, 2, size=(10,)), torch.randint(0, 2, size=(10,)).type(torch.LongTensor)))
+#
+#     with pytest.raises(ValueError):
+#         # incompatible predictions
+#         pr.update((torch.rand(10, 5), torch.randint(0, 2, size=(10, 5)).type(torch.LongTensor)))
+#
+#     with pytest.raises(ValueError):
+#         # incompatible y
+#         pr.update((torch.randint(0, 5, size=(10, 5, 6)), torch.rand(10)))
+#
+#     with pytest.raises(ValueError):
+#         # incompatible shapes between two updates
+#         pr.update((torch.randint(0, 2, size=(20, 5)), torch.randint(0, 2, size=(20, 5)).type(torch.LongTensor)))
+#         pr.update((torch.randint(0, 2, size=(20, 6)), torch.randint(0, 2, size=(20, 6)).type(torch.LongTensor)))
+#
+#
+# def to_numpy_multilabel(y):
+#     # reshapes input array to (N x ..., C)
+#     y = y.transpose(1, 0).numpy()
+#     num_classes = y.shape[0]
+#     y = y.reshape((num_classes, -1)).transpose(1, 0)
+#     return y
+#
+#
+# def test_multilabel_input_NC():
+#     def _test(average):
+#         pr = Precision(average=average, is_multilabel=True)
+#
+#         predictions = torch.randint(0, 2, size=(20, 5))
+#         y = torch.randint(0, 2, size=(20, 5)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         np_predictions = predictions.numpy()
+#         np_targets = y.numpy()
+#         assert pr._type == 'multilabel'
+#         pr_compute = pr.compute() if average else pr.compute().mean().item()
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             assert precision_score(np_targets, np_predictions, average='samples') == pytest.approx(pr_compute)
+#
+#         pr.reset()
+#         predictions = torch.randint(0, 2, size=(10, 4))
+#         y = torch.randint(0, 2, size=(10, 4)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         np_predictions = predictions.numpy()
+#         np_targets = y.numpy()
+#         assert pr._type == 'multilabel'
+#         pr_compute = pr.compute() if average else pr.compute().mean().item()
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             assert precision_score(np_targets, np_predictions, average='samples') == pytest.approx(pr_compute)
+#
+#         # Batched Updates
+#         pr.reset()
+#         predictions = torch.randint(0, 2, size=(100, 4))
+#         y = torch.randint(0, 2, size=(100, 4)).type(torch.LongTensor)
+#
+#         batch_size = 16
+#         n_iters = y.shape[0] // batch_size + 1
+#
+#         for i in range(n_iters):
+#             idx = i * batch_size
+#             pr.update((predictions[idx:idx + batch_size], y[idx:idx + batch_size]))
+#
+#         np_targets = y.numpy()
+#         np_predictions = predictions.numpy()
+#         assert pr._type == 'multilabel'
+#         pr_compute = pr.compute() if average else pr.compute().mean().item()
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             assert precision_score(np_targets, np_predictions, average='samples') == pytest.approx(pr_compute)
+#
+#     for _ in range(5):
+#         _test(average=True)
+#         _test(average=False)
+#
+#     pr1 = Precision(is_multilabel=True, average=True)
+#     pr2 = Precision(is_multilabel=True, average=False)
+#     predictions = torch.randint(0, 2, size=(10, 4, 20, 23))
+#     y = torch.randint(0, 2, size=(10, 4, 20, 23)).type(torch.LongTensor)
+#     pr1.update((predictions, y))
+#     pr2.update((predictions, y))
+#     assert pr1.compute() == pytest.approx(pr2.compute().mean().item())
+#
+#
+# def test_multilabel_input_NCL():
+#     def _test(average):
+#         pr = Precision(average=average, is_multilabel=True)
+#
+#         predictions = torch.randint(0, 2, size=(10, 5, 10))
+#         y = torch.randint(0, 2, size=(10, 5, 10)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         np_predictions = to_numpy_multilabel(predictions)
+#         np_targets = to_numpy_multilabel(y)
+#         assert pr._type == 'multilabel'
+#         pr_compute = pr.compute() if average else pr.compute().mean().item()
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             assert precision_score(np_targets, np_predictions, average='samples') == pytest.approx(pr_compute)
+#
+#         pr.reset()
+#         predictions = torch.randint(0, 2, size=(15, 4, 10))
+#         y = torch.randint(0, 2, size=(15, 4, 10)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         np_predictions = to_numpy_multilabel(predictions)
+#         np_targets = to_numpy_multilabel(y)
+#         assert pr._type == 'multilabel'
+#         pr_compute = pr.compute() if average else pr.compute().mean().item()
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             assert precision_score(np_targets, np_predictions, average='samples') == pytest.approx(pr_compute)
+#
+#         # Batched Updates
+#         pr.reset()
+#         predictions = torch.randint(0, 2, size=(100, 4, 12))
+#         y = torch.randint(0, 2, size=(100, 4, 12)).type(torch.LongTensor)
+#
+#         batch_size = 16
+#         n_iters = y.shape[0] // batch_size + 1
+#
+#         for i in range(n_iters):
+#             idx = i * batch_size
+#             pr.update((predictions[idx:idx + batch_size], y[idx:idx + batch_size]))
+#
+#         np_targets = to_numpy_multilabel(y)
+#         np_predictions = to_numpy_multilabel(predictions)
+#         assert pr._type == 'multilabel'
+#         pr_compute = pr.compute() if average else pr.compute().mean().item()
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             assert precision_score(np_targets, np_predictions, average='samples') == pytest.approx(pr_compute)
+#
+#     for _ in range(5):
+#         _test(average=True)
+#         _test(average=False)
+#
+#     pr1 = Precision(is_multilabel=True, average=True)
+#     pr2 = Precision(is_multilabel=True, average=False)
+#     predictions = torch.randint(0, 2, size=(10, 4, 20, 23))
+#     y = torch.randint(0, 2, size=(10, 4, 20, 23)).type(torch.LongTensor)
+#     pr1.update((predictions, y))
+#     pr2.update((predictions, y))
+#     assert pr1.compute() == pytest.approx(pr2.compute().mean().item())
+#
+#
+# def test_multilabel_input_NCHW():
+#     def _test(average):
+#         pr = Precision(average=average, is_multilabel=True)
+#
+#         predictions = torch.randint(0, 2, size=(10, 5, 18, 16))
+#         y = torch.randint(0, 2, size=(10, 5, 18, 16)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         np_predictions = to_numpy_multilabel(predictions)
+#         np_targets = to_numpy_multilabel(y)
+#         assert pr._type == 'multilabel'
+#         pr_compute = pr.compute() if average else pr.compute().mean().item()
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             assert precision_score(np_targets, np_predictions, average='samples') == pytest.approx(pr_compute)
+#
+#         pr.reset()
+#         predictions = torch.randint(0, 2, size=(10, 4, 20, 23))
+#         y = torch.randint(0, 2, size=(10, 4, 20, 23)).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#         np_predictions = to_numpy_multilabel(predictions)
+#         np_targets = to_numpy_multilabel(y)
+#         assert pr._type == 'multilabel'
+#         pr_compute = pr.compute() if average else pr.compute().mean().item()
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             assert precision_score(np_targets, np_predictions, average='samples') == pytest.approx(pr_compute)
+#
+#         # Batched Updates
+#         pr.reset()
+#         predictions = torch.randint(0, 2, size=(100, 5, 12, 14))
+#         y = torch.randint(0, 2, size=(100, 5, 12, 14)).type(torch.LongTensor)
+#
+#         batch_size = 16
+#         n_iters = y.shape[0] // batch_size + 1
+#
+#         for i in range(n_iters):
+#             idx = i * batch_size
+#             pr.update((predictions[idx:idx + batch_size], y[idx:idx + batch_size]))
+#
+#         np_targets = to_numpy_multilabel(y)
+#         np_predictions = to_numpy_multilabel(predictions)
+#         assert pr._type == 'multilabel'
+#         pr_compute = pr.compute() if average else pr.compute().mean().item()
+#         with warnings.catch_warnings():
+#             warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+#             assert precision_score(np_targets, np_predictions, average='samples') == pytest.approx(pr_compute)
+#
+#     for _ in range(5):
+#         _test(average=True)
+#         _test(average=False)
+#
+#     pr1 = Precision(is_multilabel=True, average=True)
+#     pr2 = Precision(is_multilabel=True, average=False)
+#     predictions = torch.randint(0, 2, size=(10, 4, 20, 23))
+#     y = torch.randint(0, 2, size=(10, 4, 20, 23)).type(torch.LongTensor)
+#     pr1.update((predictions, y))
+#     pr2.update((predictions, y))
+#     assert pr1.compute() == pytest.approx(pr2.compute().mean().item())
+#
+#
+# def test_incorrect_type():
+#     # Tests changing of type during training
+#
+#     def _test(average):
+#         pr = Precision(average=average)
+#
+#         predictions = torch.softmax(torch.rand(4, 4), dim=1)
+#         y = torch.ones(4).type(torch.LongTensor)
+#         pr.update((predictions, y))
+#
+#         predictions = torch.randint(0, 2, size=(4,))
+#         y = torch.ones(4).type(torch.LongTensor)
+#
+#         with pytest.raises(RuntimeError):
+#             pr.update((predictions, y))
+#
+#     _test(average=True)
+#     _test(average=False)
+#
+#     pr1 = Precision(is_multilabel=True, average=True)
+#     pr2 = Precision(is_multilabel=True, average=False)
+#     predictions = torch.randint(0, 2, size=(10, 4, 20, 23))
+#     y = torch.randint(0, 2, size=(10, 4, 20, 23)).type(torch.LongTensor)
+#     pr1.update((predictions, y))
+#     pr2.update((predictions, y))
+#     assert pr1.compute() == pytest.approx(pr2.compute().mean().item())
+#
+#
+# def test_incorrect_y_classes():
+#     def _test(average):
+#         pr = Precision(average=average)
+#
+#         predictions = torch.randint(0, 2, size=(10, 4)).float()
+#         y = torch.randint(4, 5, size=(10,)).long()
+#
+#         with pytest.raises(ValueError):
+#             pr.update((predictions, y))
+#
+#     _test(average=True)
+#     _test(average=False)
+
+
+if __name__ == 'main':
+    unittest.main()
+


### PR DESCRIPTION
Why don't we just use the ignite's metrics ?
We could just adapt our gauge (currently not defined) object to these metrics. Everything is tested in this lib and code quality isn't bad at all.
The update() method from ignite's lib updates the internal metric’s state using the passed batch output, which is called every batch, and the compute() method is called every epoch. So we could only pass the result of the compute() method to the gauge for visualisation.
The code here is really similar to the ignite's lib, excepted I removed the update() function to use it every training iteration.
This is more a programming trip rather than really bringing something useful to the lib. I think we should adopt at least the ignite.metrics package and force users to adopt ignite.metrics interface for creating new metrics.